### PR TITLE
Fix sidebar performance active state

### DIFF
--- a/static/app/components/sidebar/sidebarItem.spec.tsx
+++ b/static/app/components/sidebar/sidebarItem.spec.tsx
@@ -1,0 +1,19 @@
+import {isItemActive} from 'sentry/components/sidebar/sidebarItem';
+
+describe('isItemActive', function () {
+  it('is not active for settings performance path', function () {
+    window.location.pathname = '/settings/projects/test-slug/performance/';
+
+    expect(
+      isItemActive({label: 'Performance', to: '/performance/'})
+    ).toBe(false);
+  });
+
+  it('is active for performance path', function () {
+    window.location.pathname = '/performance/';
+
+    expect(
+      isItemActive({label: 'Performance', to: '/performance/'})
+    ).toBe(true);
+  });
+});

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -335,7 +335,9 @@ export function isItemActive(
       location.pathname.includes('/alerts/') &&
       !location.pathname.startsWith('/settings/')) ||
     (item?.label === 'Releases' && location.pathname.includes('/release-thresholds/')) ||
-    (item?.label === 'Performance' && location.pathname.includes('/performance/'))
+    (item?.label === 'Performance' &&
+      location.pathname.includes('/performance/') &&
+      !location.pathname.startsWith('/settings/'))
   );
 }
 


### PR DESCRIPTION
## Summary
- prevent the sidebar Performance item from being active on settings pages
- add test for sidebar isItemActive logic

## Testing
- `yarn test static/app/components/sidebar/sidebarItem.spec.tsx` *(fails: package not in lockfile)*